### PR TITLE
Add first draft of generic RO construction, and separate encoding and hashing functions

### DIFF
--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -617,7 +617,7 @@ where alpha is a message to encode on a curve.
 
 When applications need a Random Oracle (RO), they can be constructed from deterministic encoding 
 functions. In particular, let F : {0,1}^* -> E be a deterministic encoding function onto 
-curve E, and let H1 and H2 be two hash functions modeled as random oracles that map input 
+curve E, and let H0 and H1 be two hash functions modeled as random oracles that map input 
 messages to the base field of E, i.e., Z_q. Farashahi et al. {{FFSTV13}} showed that the 
 following mapping is indistinguishable from a RO:
 
@@ -627,7 +627,7 @@ hash2curve(alpha) = F(H0(alpha)) + F(H1(alpha))
 
 This construction works for the Icart, SWU, and Simplfied SWU encodings. 
 
-Here, H1 and H2 could be constructed as follows:
+Here, H0 and H1 could be constructed as follows:
 
 ~~~
 H0(alpha) = HashToBase(0 || alpha)

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -252,7 +252,7 @@ we write n = qh + r, where q is prime, and h is said to be the cofactor.
 It is frequently a requirement that all cryptographic operations take place
 in a prime order group. In this case, we may wish an encoding to return
 elements of order q. For a mapping outputting elements on E, we can
-multiply by the cofactor h to obtain an element in ths subgroup.
+multiply by the cofactor h to obtain an element in the subgroup.
 
 In practice, the input of a given cryptographic algorithm will be a bitstring of
 arbitrary length, denoted  {0, 1}^\*. Hence, a concern for virtually all protocols
@@ -265,7 +265,7 @@ approximately a 1/2 chance that there exist a corresponding y value such that
 this sums to approximately p points.
 
 Ultimately, an encoding function takes a bitstring {0, 1}^\* to an element
-of E, of order n (or q), and represnted by variables in GF(p).
+of E, of order n (or q), and represented by variables in GF(p).
 
 Summary of quantities:
 
@@ -351,45 +351,14 @@ The following table lists algorithms recommended by use-case:
 To find the suitable algorithm, lookup the requirement from above, with 
 the chosen curve in the below:
 
-
 | Curve  | Inj. Encoding | Random Oracle |
 |--------|---------------|------|
-| P-256 | SWU {{simple-swu}} | FFSTV(SWU)
-| P-384 | Icart {{icart}} | FFSTV(Icart)
-| Curve25519 | Elligator2 {{elligator2}} | ...
-| Curve448 | Elligator2 {{elligator2}} | ...
+| P-256 | SWU {{simple-swu}} | FFSTV(SWU) 
+| P-384 | Icart {{icart}} | FFSTV(Icart) 
+| Curve25519 | Elligator2 {{elligator2}} | ... 
+| Curve448 | Elligator2 {{elligator2}} | ... 
 
-
-The following table lists recommended algorithms to use for specific curves. 
-
-| Curve | Algorithm |
-| P-256 | SWU {{simple-swu}} |
-| P-384 | Icart {{icart}} |
-| Curve25519 | Elligator2 {{elligator2}} |
-| Curve448 | Elligator2 {{elligator2}} |
-
-The SWU variant from Section {{swu}} applies to any curve. As such, this algorithm
-SHOULD be used if no other better alternative is known. More efficient variants and
-their curve requirements are shown in the table below. These MAY be used if the target
-curve meets the listed criteria.
-
-| Algorithm | Requirement |
-| Icart {{icart}} | p = 2 mod 3 |
-| SWU {{swu}} | None |
-| Simplified SWU {{simple-swu}} | p = 3 mod 4 |
-| Elligator2 {{elligator2}} | p is large and there is a point of order two and j-invariant != 1728 |
-
-# Generic Interface
-
-The generic interface for hashing to elliptic curves is as follows:
-
-~~~
-hash_to_curve(alpha)
-~~~
-
-where alpha is a message to hash onto a curve. 
-
-## Utility Functions
+# Utility Functions
 
 Algorithms in this document make use of utility functions described below.
 
@@ -402,13 +371,23 @@ Note: We assume that HashToBase maps its input to the base field uniformly.
 In practice, there may be inherent biases in p, e.g., p = 2^k - 1 will
 have non-negligible bias in higher bits.
 
-((TODO: expand on this problem))
+# Deterministic Encodings
 
-# Hashing Variants
+## Interface
 
-## Icart Method {#icart}
+The generic interface for deterministic encoding functions to elliptic curves is as follows:
 
-The following hash_to_curve_icart(alpha) implements the Icart method from {{Icart09}}.
+~~~
+map2curve(alpha)
+~~~
+
+where alpha is a message to encode on a curve. 
+
+## Encoding Variants
+
+### Icart Method {#icart}
+
+The following map2curve_icart(alpha) implements the Icart method from {{Icart09}}.
 This algorithm works for any curve over F_{p^n}, where p^n = 2 mod 3 
 (or p = 2 mod 3 and for odd n), including:
 
@@ -435,7 +414,7 @@ It requires knowledge of A and B, the constants from the curve Weierstrass form.
 It outputs a point with affine coordinates.
 
 ~~~
-hash_to_curve_icart(alpha)
+map2curve_icart(alpha)
 
 Input:
 
@@ -472,13 +451,13 @@ Steps:
 
 ~~~
 
-## Shallue-Woestijne-Ulas Method {#swu}
+### Shallue-Woestijne-Ulas Method {#swu}
 
 ((TODO: write this section))
 
-## Simplified SWU Method {#simple-swu}
+### Simplified SWU Method {#simple-swu}
 
-The following hash_to_curve_simple_swu(alpha) implements the simplfied
+The following map2curve_simple_swu(alpha) implements the simplfied
 Shallue-Woestijne-Ulas algorithm from {{SimpleSWU}}. This algorithm
 works for any curve over F_{p^n}, where p = 3 mod 4, including:
 
@@ -499,11 +478,11 @@ The following procedure implements this algorithm. It outputs a point with
 affine coordinates.
 
 ~~~
-hash_to_curve_simple_swu(alpha)
+map2curve_simple_swu(alpha)
 
 Input:
 
-  alpha - value to be hashed, an octet string
+  alpha - value to be encoded, an octet string
 
 Output:
 
@@ -537,9 +516,9 @@ Steps:
 24. Output (x, y)
 ~~~
 
-## Elligator2 Method {#elligator2}
+### Elligator2 Method {#elligator2}
 
-The following hash_to_curve_elligator2(alpha) implements the Elligator2
+The following map2curve_elligator2(alpha) implements the Elligator2
 method from {{Elligator2}}. This algorithm works for any curve
 with a point of order 2 and j-invariant != 1728. Given curve equation 
 f(x) = y^2 = x(x^2 + Ax + B), i.e., a Montgomery form with the point of 
@@ -569,11 +548,11 @@ the Legendre symbol.)
 The following procedure implements this algorithm.
 
 ~~~
-hash_to_curve_elligator2(alpha)
+map2curve_elligator2(alpha)
 
 Input:
 
-  alpha - value to be hashed, an octet string
+  alpha - value to be encoded, an octet string
 
   u - fixed non-square value in Fp.
   f() - Curve function
@@ -609,22 +588,59 @@ Elligator2 can be simplified with projective coordinates.
 
 ((TODO: write this variant))
 
-# Curve Transformations
+## Cost Comparison
 
-((TODO: write this section))
-
-# Cost Comparison
-
-The following table summarizes the cost of each hash_to_curve variant. We express this cost in 
+The following table summarizes the cost of each map2curve variant. We express this cost in 
 terms of additions (A), multiplications (M), squares (SQ), and square roots (SR). 
 
 ((TODO: finish this section))
 
 | Algorithm | Cost (Operations) | 
-| hash_to_curve_icart | TODO |
-| hash_to_curve_swu | TODO |
-| hash_to_curve_simple_swu | TODO |
-| hash_to_curve_elligator2 | TODO |
+| map2curve_icart | TODO |
+| map2curve_swu | TODO |
+| map2curve_simple_swu | TODO |
+| map2curve_elligator2 | TODO |
+
+# Random Oracles
+
+## Interface
+
+The generic interface for deterministic encoding functions to elliptic curves is as follows:
+
+~~~
+hash2curve(alpha)
+~~~
+
+where alpha is a message to encode on a curve. 
+
+## General Construction (FFSTV13)
+
+When applications need a Random Oracle (RO), they can be constructed from deterministic encoding 
+functions. In particular, let F : {0,1}^* -> E be a deterministic encoding function onto 
+curve E, and let H1 and H2 be two hash functions modeled as random oracles that map input 
+messages to the base field of E, i.e., Z_q. Farashahi et al. {{FFSTV13}} showed that the 
+following mapping is indistinguishable from a RO:
+
+~~~
+hash2curve(alpha) = F(H0(alpha)) + F(H1(alpha))
+~~~
+
+This construction works for the Icart, SWU, and Simplfied SWU encodings. 
+
+Here, H1 and H2 could be constructed as follows:
+
+~~~
+H0(alpha) = HashToBase(0 || alpha)
+H1(alpha) = HashToBase(1 || alpha)
+~~~
+
+## Curve-Specific Variants
+
+((TODO: write this section))
+
+# Curve Transformations
+
+((TODO: write this section))
 
 # IANA Considerations
 
@@ -632,9 +648,9 @@ This document has no IANA actions.
 
 # Security Considerations
 
-Each hash function variant accepts arbitrary input and maps it to a pseudorandom
+Each encoding function variant accepts arbitrary input and maps it to a pseudorandom
 point on the curve. Points are close to indistinguishable from randomly chosen 
-elements on the curve. Some variants variants are not full-domain hashes. Elligator2,
+elements on the curve. Not all encoding functions are full-domain hashes. Elligator2,
 for example, only maps strings to "about half of all curve points," whereas Icart's
 method only covers about 5/8 of the points.
 
@@ -771,7 +787,7 @@ defined in Section 4.1 of {{RFC8017}}, and RS2ECP is a function that converts of
 
 ## Icart Method
 
-The following Sage program implements hash_to_curve_icart(alpha) for P-384.
+The following Sage program implements map2curve_icart(alpha) for P-384.
 
 ~~~
 p = 394020061963944792122790401001436138050797392704654466679482934042 \
@@ -838,7 +854,7 @@ def icart_straight(u):
 
 ## Simplified SWU Method
 
-The following Sage program implements hash_to_curve_swu(alpha) for P-256.
+The following Sage program implements map2curve_swu(alpha) for P-256.
 
 ~~~
 p = 115792089210356248762697446949407573530086143415290314195533631308 \
@@ -910,7 +926,7 @@ def simple_swu_straight(alpha):
 
 ## Elligator2 Method
 
-The following Sage program implements hash_to_curve_elligator2(alpha) for Curve25519.
+The following Sage program implements map2curve_elligator2(alpha) for Curve25519.
 
 ~~~
 p = 2**255 - 19

--- a/poc/elligator2_hacspec.py
+++ b/poc/elligator2_hacspec.py
@@ -1,0 +1,18 @@
+from curve25519 import *
+from speclib import *
+
+a25519 = felem(486662)
+b25519 = felem(1)
+u25519 = felem(2)
+
+def f_25519(x:felem_t) -> felem_t:
+    return fadd(fmul(x, fsqr(x)), fadd(fmul(a25519, fsqr(x)), x))
+
+def hash2curve25519(r:felem_t) -> point_t:
+    d = felem(p25519 - fmul(a25519,finv(fadd(1,fmul(u25519,fsqr(r))))))
+    power = nat((p25519 - 1) // 2)
+    e = fexp(f_25519(d), power)
+    if e != 1:
+        return fsub(-d, a25519)
+    else:
+        return d

--- a/poc/simple_swu_hacspec.py
+++ b/poc/simple_swu_hacspec.py
@@ -1,0 +1,22 @@
+from p256 import *
+from speclib import *
+
+a256 = felem(p256.prime - 3)
+b256 = felem(41058363725152142129326129780047268409114441015993725554835256314039467401291)
+
+def hash2curveSimpleSWU(t:felem_t) -> point_t:
+    alpha = felem(fmul(-1, fsqr(t)))
+    frac = finv(fadd(fsqr(alpha), alpha))
+
+    x2 = fmul(fmul(fmul(-1, b256), finv(a256)), fadd(1, frac))
+    x3 = fmul(alpha,  x2)
+
+    h2 = fadd(fadd(fexp(x2, 3), fmul(a256, x2)), b256)
+    h3 = fadd(fadd(fexp(x3, 3), fmul(a256, x3)), b256)
+
+    sqr = fexp(h2, (p + 1) // 4)
+    if sqr == x2^2:
+        return x2
+    else:
+        return x3
+


### PR DESCRIPTION
This is a first cut at #23. It doesn't go into details regarding what is a suitable encoding for the construction, although all those considered (except Elligator2) were shown to work. (@samscott89, we should do the math and figure out if Elligator2 works.)